### PR TITLE
Add full file path when using clean_up function

### DIFF
--- a/get_latest.sh
+++ b/get_latest.sh
@@ -97,14 +97,14 @@ ckcc_firmware() {
   fi
 
   if verify_sha256sum "$SIGNATURE_FILE_NAME"; then
-    clean_up "$SIGNATURE_FILE_NAME"
+    clean_up "$DOWNLOAD_DIR/$SIGNATURE_FILE_NAME"
     echo ""
     echo "  MESSAGE:  Please leave $PACKAGE_NAME in"
     echo "  MESSAGE:  $DOWNLOAD_DIR after you have"
     echo "  MESSAGE:  updated your device so this script can tell what"
     echo "  MESSAGE:  version you have installed!"
   else
-    clean_up "$SIGNATURE_FILE_NAME" "$PACKAGE_NAME"
+    clean_up "$DOWNLOAD_DIR/$SIGNATURE_FILE_NAME" "$DOWNLOAD_DIR/$PACKAGE_NAME"
     return 1
   fi
 

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -118,13 +118,12 @@ clean_up() {
     fi
 
     local ARGUMENTS=( $@ )
-    local CLEAN_UP_DIR=$(pwd)
 
     for ((i=0; i < $#; i++)); do
       if ! [ -z "${ARGUMENTS[$i]}" ]; then
         if [[ -f "${ARGUMENTS[$i]}" || -d "${ARGUMENTS[$i]}" ]]; then
           $SUDO rm -rf "${ARGUMENTS[$i]}"
-          echo "  DELETED:  $CLEAN_UP_DIR/${ARGUMENTS[$i]}"
+          echo "  DELETED:  ${ARGUMENTS[$i]}"
         fi
       fi
     done


### PR DESCRIPTION
This PR modifies how the clean_up function is called such that it no longer uses a local variable to display to the user the file path and file that was deleted.

It also updates where it is used in get_latest.sh so that arguments now contain the full path to the file wanting to be deleted.